### PR TITLE
Dja7394/count loc

### DIFF
--- a/count_loc.py
+++ b/count_loc.py
@@ -1,0 +1,22 @@
+import os
+
+CODE_FILE_WHITELIST = ['.py', '.js', '.html', '.css']
+
+def getNumberOfLinesInFile(filepath):
+    return sum(1 for line in open(filepath, 'r'))
+
+def countLinesOfCode():
+    totalLinesOfCode = 0
+
+    for path, subdirs, files in os.walk('.'):
+        for filename in files:
+            if any(filename.endswith(extension) for extension in CODE_FILE_WHITELIST):
+                filepath = os.path.join(path, filename)
+                linesOfCode = getNumberOfLinesInFile(filepath)
+
+                totalLinesOfCode += linesOfCode
+
+    print('Total lines of code: {} ({} kLOC)'.format(totalLinesOfCode, totalLinesOfCode // 1000))
+
+if __name__ == '__main__':
+    countLinesOfCode()

--- a/count_loc.py
+++ b/count_loc.py
@@ -1,20 +1,31 @@
+#!/usr/bin/python3
+
 import os
 
+SEARCH_DIRECTORIES = ['page'] # What directories to recursively search
 CODE_FILE_WHITELIST = ['.py', '.js', '.html', '.css']
 
 def getNumberOfLinesInFile(filepath):
     return sum(1 for line in open(filepath, 'r'))
 
-def countLinesOfCode():
+def countLinesOfCodeInRoot(root):
     totalLinesOfCode = 0
 
-    for path, subdirs, files in os.walk('.'):
+    for path, subdirs, files in os.walk(root):
         for filename in files:
             if any(filename.endswith(extension) for extension in CODE_FILE_WHITELIST):
                 filepath = os.path.join(path, filename)
                 linesOfCode = getNumberOfLinesInFile(filepath)
 
                 totalLinesOfCode += linesOfCode
+
+    return totalLinesOfCode
+
+def countLinesOfCode():
+    totalLinesOfCode = 0
+
+    for dir in SEARCH_DIRECTORIES:
+        totalLinesOfCode += countLinesOfCodeInRoot(dir)
 
     print('Total lines of code: {} ({} kLOC)'.format(totalLinesOfCode, totalLinesOfCode // 1000))
 

--- a/tools/count_loc.py
+++ b/tools/count_loc.py
@@ -2,7 +2,7 @@
 
 import os
 
-SEARCH_DIRECTORIES = ['page'] # What directories to recursively search
+SEARCH_DIRECTORIES = ['page', 'tools'] # What directories to recursively search
 CODE_FILE_WHITELIST = ['.py', '.js', '.html', '.css']
 
 def getNumberOfLinesInFile(filepath):
@@ -25,7 +25,8 @@ def countLinesOfCode():
     totalLinesOfCode = 0
 
     for dir in SEARCH_DIRECTORIES:
-        totalLinesOfCode += countLinesOfCodeInRoot(dir)
+        searchDir = os.path.join('..', dir)
+        totalLinesOfCode += countLinesOfCodeInRoot(searchDir)
 
     print('Total lines of code: {} ({} kLOC)'.format(totalLinesOfCode, totalLinesOfCode // 1000))
 


### PR DESCRIPTION
Adds a tool to count lines of code. It can be configured to recursively search a set of subdirectories and whitelists certain file extensions. This will get used to count the lines of code for our metrics.