### PR TITLE
Build exe on all pushes, and fix sound dependency

### DIFF
--- a/.github/workflows/build_exe.yml
+++ b/.github/workflows/build_exe.yml
@@ -1,8 +1,6 @@
 name: Build Executeable
 
-on:
-  push:
-    branches: [ main ]
+on: [push]
 
 jobs:
   archive-linux-artifact:
@@ -19,6 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt-get install -y libasound2-dev
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi


### PR DESCRIPTION
This somehow got lost in all the merges. Made it so the exe gets built on all runs so that we don't have to keep fixing after merge