### PR TITLE
Upped all testing timeouts

### DIFF
--- a/test/mixing_tests/mixing_test.py
+++ b/test/mixing_tests/mixing_test.py
@@ -29,7 +29,7 @@ class TestDeactivate():
         assert expected == actual
 
 class TestRun:
-    @pytest.mark.timeout(0.5)
+    @pytest.mark.timeout(5) #Longer timeout than strictly nesscary, to allow for slower computers
     def test_exits(self):
         test_shared_queues = SharedQueues()
         test_shared_queues.create_queues()
@@ -39,7 +39,7 @@ class TestRun:
 
         component.deactivate()
     
-    @pytest.mark.timeout(1)
+    @pytest.mark.timeout(5)
     def test_pulls_from_button(self):
         test_shared_queues = SharedQueues()
         test_shared_queues.create_queues()
@@ -56,7 +56,7 @@ class TestRun:
 
         assert test_event == actual
 
-    @pytest.mark.timeout(1)
+    @pytest.mark.timeout(5)
     def test_pulls_from_file(self):
         test_shared_queues = SharedQueues()
         test_shared_queues.create_queues()

--- a/test/output_queue_tests/output_queue_test.py
+++ b/test/output_queue_tests/output_queue_test.py
@@ -69,7 +69,7 @@ class TestPorts:
             output_queue.select_device(bad_device_name)
 
 class TestRun:
-    @pytest.mark.timeout(0.5)
+    @pytest.mark.timeout(5)
     def test_deactivate(self):
         sync_manager = SharedQueueSyncManager()
         output_queue = OutputQueue(sync_manager.PeekingPriorityQueue())


### PR DESCRIPTION
A low testing timeout was causing failed tests on slower hardware. Hopefully this clears up the failing local tests